### PR TITLE
Update chai & refactor tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18, 20, 22 ]
+        node-version: [ 18, 20, 21 ]
 
     steps:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "^1.6.2"
       },
       "devDependencies": {
-        "chai": "^4.3.10",
+        "chai": "^5.1.0",
         "eslint": "^8.53.0",
         "mocha": "^10.2.0",
         "nock": "^13.3.8",
@@ -951,12 +951,12 @@
       "dev": true
     },
     "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -1095,21 +1095,19 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.0.tgz",
+      "integrity": "sha512-kDZ7MZyM6Q1DhR9jy7dalKohXQ2yrlXkk59CR52aRKxJrobmlBNqnFQxX9xOX8w+4mz8SYlKJa/7D7ddltFXCw==",
       "dev": true,
       "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.0.0",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
       }
     },
     "node_modules/chalk": {
@@ -1129,15 +1127,12 @@
       }
     },
     "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
+      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
       "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
       "engines": {
-        "node": "*"
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1287,13 +1282,10 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
+      "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
       "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
       "engines": {
         "node": ">=6"
       }
@@ -2285,12 +2277,12 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.0.tgz",
+      "integrity": "sha512-qKl+FrLXUhFuHUoDJG7f8P8gEMHq9NFS0c6ghXG1J0rldmZFQZoNVv/vyirE9qwCIhWZDsvEFd1sbFu3GvRQFg==",
       "dev": true,
       "dependencies": {
-        "get-func-name": "^2.0.0"
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
@@ -2844,12 +2836,12 @@
       }
     },
     "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -4295,9 +4287,9 @@
       "dev": true
     },
     "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true
     },
     "asynckit": {
@@ -4395,18 +4387,16 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.0.tgz",
+      "integrity": "sha512-kDZ7MZyM6Q1DhR9jy7dalKohXQ2yrlXkk59CR52aRKxJrobmlBNqnFQxX9xOX8w+4mz8SYlKJa/7D7ddltFXCw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.0.0",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       }
     },
     "chalk": {
@@ -4420,13 +4410,10 @@
       }
     },
     "check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "requires": {
-        "get-func-name": "^2.0.2"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
+      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -4540,13 +4527,10 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
+      "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -5258,12 +5242,12 @@
       }
     },
     "loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.0.tgz",
+      "integrity": "sha512-qKl+FrLXUhFuHUoDJG7f8P8gEMHq9NFS0c6ghXG1J0rldmZFQZoNVv/vyirE9qwCIhWZDsvEFd1sbFu3GvRQFg==",
       "dev": true,
       "requires": {
-        "get-func-name": "^2.0.0"
+        "get-func-name": "^2.0.1"
       }
     },
     "lru-cache": {
@@ -5706,9 +5690,9 @@
       }
     },
     "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
       "dev": true
     },
     "picocolors": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "author": "Zota Technology Pte LTD",
   "version": "1.3.1",
   "description": "This Node.js SDK provides all the necessary methods for integrating the Zotapay Merchant API.",
-  
   "repository": {
     "type": "git",
     "url": "https://github.com/zotapay/node-sdk.git"
@@ -26,12 +25,12 @@
     "test": "nyc --reporter=lcov mocha",
     "pretest": "eslint --ignore-path .gitignore ."
   },
-  "engines" : { 
-    "node" : ">=16.0.0"
+  "engines": {
+    "node": ">=16.0.0"
   },
   "type": "commonjs",
   "devDependencies": {
-    "chai": "^4.3.10",
+    "chai": "^5.1.0",
     "eslint": "^8.53.0",
     "mocha": "^10.2.0",
     "nock": "^13.3.8",

--- a/test/test_config.js
+++ b/test/test_config.js
@@ -3,15 +3,16 @@ const config = require("./../zotapaysdk/config.js");
 const MGCredentialsManager = config.MGCredentialsManager;
 const CredentialKeys = config.CredentialKeys;
 
-const expect = require("chai").expect
 const sinon = require("sinon");
 
+
 describe("Credential configuration tests", function () {
-
-
-    var env
-    // mocking an environment
-    before(function () {
+    
+    var expect;
+    var env;
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
         env = process.env;
         sinon.stub(MGCredentialsManager.prototype, "getConfig").callsFake( () => { return "";});
     });

--- a/test/test_core.js
+++ b/test/test_core.js
@@ -1,8 +1,13 @@
-const assert = require("chai").assert
 const MGRequestParam = require("../zotapaysdk/mg_requests/objects.js").MGRequestParam
+
 
 describe("MGRequestParam tests", function () {
 
+    var assert;
+    before(async () => {
+        const chai = await import('chai');
+        assert = chai.assert;
+    });
 
     it("MGRequestParam success test", function () {
 

--- a/test/test_deposit.js
+++ b/test/test_deposit.js
@@ -1,15 +1,22 @@
-const {assert, expect} = require("chai");
 const {generateTestOrderWithOkResponse, MockResponse, generateTestOrder, TestCreditCards} = require("../zotapaysdk/testing_tools");
 const {MGClient} = require("../zotapaysdk/client");
 const {MGDepositRequest} = require("../zotapaysdk/mg_requests/deposit_request");
 const {MGDepositResponse} = require("../zotapaysdk/mg_requests/deposit_response");
-
-const nock = require("nock")
 const {DepositRequestParameters} = require("../zotapaysdk/mg_requests/mg_request");
 const {MGCardDepositRequest} = require("../zotapaysdk/mg_requests/card_deposit_request");
 const {MGCardDepositResponse} = require("../zotapaysdk/mg_requests/card_deposit_response");
+
+const nock = require("nock")
+
+
 describe("Deposit tests", function () {
 
+    var assert, expect;
+    before(async () => {
+        const chai = await import('chai');
+        assert = chai.assert;
+        expect = chai.expect;
+    });
 
     it("Deposit test success", async () => {
 

--- a/test/test_order_status.js
+++ b/test/test_order_status.js
@@ -2,12 +2,20 @@ const {MockResponse, generateOrderStatusCheckOkPayload,
     generateOrderStatusCheckNotOkPayload
 } = require("../zotapaysdk/testing_tools");
 const {MGClient} = require("../zotapaysdk/client");
-const nock = require("nock");
-const {assert} = require("chai");
 const {MGOrderStatusRequest} = require("../zotapaysdk/mg_requests/order_status_request");
 const {MGOrderStatusResponse} = require("../zotapaysdk/mg_requests/order_status_response");
 
+const nock = require("nock");
+
+
 describe("Order Status tests", function () {
+    
+    var assert;
+    before(async () => {
+        const chai = await import('chai');
+        assert = chai.assert;
+    });
+
     it("Order status test success", async () => {
 
         const orderStatusCheckParameters = {

--- a/test/test_payout.js
+++ b/test/test_payout.js
@@ -2,12 +2,20 @@ const {MockResponse, generateTestPayoutWithOkResponse,
     generateTestPayoutWithNotOkResponse, generateTestPayout
 } = require("../zotapaysdk/testing_tools");
 const {MGClient} = require("../zotapaysdk/client");
-const nock = require("nock");
-const {assert} = require("chai");
 const {MGPayoutResponse} = require("../zotapaysdk/mg_requests/payout_response");
 const {MGPayoutRequest} = require("../zotapaysdk/mg_requests/payout_request");
 
+const nock = require("nock");
+
+
 describe("Payout tests", function () {
+    
+    var assert;
+    before(async () => {
+        const chai = await import('chai');
+        assert = chai.assert;
+    });
+    
     it("Payout test success", async () => {
 
         let [payoutPayload, responsePayload] = generateTestPayoutWithOkResponse(500, "MYR")
@@ -90,4 +98,4 @@ describe("Payout tests", function () {
         }
 
     })
-    });
+});

--- a/test/test_signature.js
+++ b/test/test_signature.js
@@ -4,9 +4,14 @@ const {generateTestOrder, generateTestPayout} = require("../zotapaysdk/testing_t
 const {DepositRequestParameters, PayoutRequestParameters} = require("../zotapaysdk/mg_requests/mg_request");
 const {MGClient} = require("../zotapaysdk/client");
 
-const {assert} = require("chai");
+
 describe("Signature tests", function () {
 
+    var assert;
+    before(async () => {
+        const chai = await import('chai');
+        assert = chai.assert;
+    });
 
     it("Deposit signature", () => {
         const expectedSignature = "4289ea00fd365d9b59689745b743839f101dc679f9e420022edac099290b161f"
@@ -55,4 +60,4 @@ describe("Signature tests", function () {
 
         assert(expectedSignature === signature, "There is a mismatch in signatures")
     })
-})
+});


### PR DESCRIPTION
## Summary

- Update chai to latest (5.1.0)
- Update chai import in tests
- Small cosmetic changes to ensure consistency across test files

This PR will resolve the [Dependabot PR for the same dependency](https://github.com/zota/node-sdk/pull/35)